### PR TITLE
Implement key imports

### DIFF
--- a/pygpg/commands/import_export.py
+++ b/pygpg/commands/import_export.py
@@ -1,0 +1,58 @@
+import sys
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import click
+import gnupg
+
+
+@click.command("import")
+@click.argument("file", type=click.Path(exists=True, readable=True, resolve_path=True))
+@click.pass_obj
+def import_key(gpg: gnupg.GPG, file: str):
+    """Import one or many GPG keys.
+
+    FILE can be an archive, directory, or individual key file.
+    If FILE is a directory or an archive, all keys contained within
+    will be imported. In the case of an archive, the keys must be
+    at the top level of the archive (not in a directory in the archive).
+    """
+    path = Path(file)
+    if path.is_dir():
+        import_keys_in_dir(gpg, path)
+        return
+
+    try:
+        imported_keys = import_key_from_file(gpg, path)
+        if imported_keys:
+            click.secho(
+                f"Imported {imported_keys} key{'s' if imported_keys > 1 or imported_keys == 0 else ''}", fg="green"
+            )
+            return
+    except UnicodeDecodeError:
+        # This must mean that the user supplied an archive instead of a file
+        pass
+
+    with TemporaryDirectory() as temp_dir:
+        try:
+            shutil.unpack_archive(path, temp_dir)
+            import_keys_in_dir(gpg, Path(temp_dir))
+        except ValueError:
+            click.secho("The archive extension is not known, keys cannot be extracted", fg="red")
+
+
+def import_keys_in_dir(gpg: gnupg.GPG, dir_path: Path):
+    files = [file for file in dir_path.glob("*") if file.is_file()]
+
+    total_count = 0
+    for file in files:
+        total_count += import_key_from_file(gpg, file)
+
+    click.secho(f"Imported {total_count} key{'s' if total_count > 1 or total_count == 0 else ''}", fg="green")
+
+
+def import_key_from_file(gpg: gnupg.GPG, file: Path) -> int:
+    with open(file, "r") as f:
+        result = gpg.import_keys(f.read())
+        return result.count

--- a/pygpg/commands/import_export.py
+++ b/pygpg/commands/import_export.py
@@ -1,4 +1,4 @@
-import sys
+"""This module contains the code for the import and export commands."""
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -23,16 +23,10 @@ def import_key(gpg: gnupg.GPG, file: str):
         import_keys_in_dir(gpg, path)
         return
 
-    try:
-        imported_keys = import_key_from_file(gpg, path)
-        if imported_keys:
-            click.secho(
-                f"Imported {imported_keys} key{'s' if imported_keys > 1 or imported_keys == 0 else ''}", fg="green"
-            )
-            return
-    except UnicodeDecodeError:
-        # This must mean that the user supplied an archive instead of a file
-        pass
+    imported_keys = import_key_from_file(gpg, path)
+    if imported_keys:
+        click.secho(f"Imported {imported_keys} key{'s' if imported_keys > 1 or imported_keys == 0 else ''}", fg="green")
+        return
 
     with TemporaryDirectory() as temp_dir:
         try:
@@ -43,6 +37,11 @@ def import_key(gpg: gnupg.GPG, file: str):
 
 
 def import_keys_in_dir(gpg: gnupg.GPG, dir_path: Path):
+    """Import all the GPG keys in a directory.
+
+    :param gpg: The GPG interface used by the gnupg library
+    :param dir_path: The path to the directory from which to import keys
+    """
     files = [file for file in dir_path.glob("*") if file.is_file()]
 
     total_count = 0
@@ -53,6 +52,17 @@ def import_keys_in_dir(gpg: gnupg.GPG, dir_path: Path):
 
 
 def import_key_from_file(gpg: gnupg.GPG, file: Path) -> int:
-    with open(file, "r") as f:
-        result = gpg.import_keys(f.read())
-        return result.count
+    """Import GPG keys from a file.
+
+    :param gpg: The GPG interface used by the gnupg library
+    :param file: The file from which to import keys
+    :return:
+    """
+    with open(file, "r") as open_file:
+        result = 0
+        try:
+            result = gpg.import_keys(open_file.read()).count
+        except UnicodeDecodeError:
+            pass
+
+        return result

--- a/pygpg/main.py
+++ b/pygpg/main.py
@@ -7,6 +7,7 @@ import gnupg
 
 from pygpg.commands.ls import ls
 from pygpg.commands.renew import renew
+from pygpg.commands.import_export import import_key
 
 
 @click.group()
@@ -61,6 +62,7 @@ def main(
 
 main.add_command(ls)
 main.add_command(renew)
+main.add_command(import_key)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Keys can now be imported in several different ways, such as from a file,
from a directory or from an archive. In the case of an archive or a directory,
all keys contained within will be imported.

Release: #minor